### PR TITLE
Add no_std support

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -3,8 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 //! In-place sorting.
+#![cfg_attr(not(test), no_std)]
+#[cfg(test)]
+extern crate std as core;
 
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 fn quicksort_helper<T, F>(arr: &mut [T], left: isize, right: isize, compare: &F)
 where F: Fn(&T, &T) -> Ordering {


### PR DESCRIPTION
Can I get an 1.1.0 release after that, pretty please?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-quicksort/2)
<!-- Reviewable:end -->
